### PR TITLE
`Development`: SwiftLint 0.54.0

### DIFF
--- a/ArtemisExamCheck.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ArtemisExamCheck.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ls1intum/artemis-ios-core-modules",
       "state" : {
-        "revision" : "56dc7c0cae3641c95c14a3369688cb121ae83219",
-        "version" : "7.0.1"
+        "revision" : "068138a4629a43e2dc47b1834d17b262911c95aa",
+        "version" : "7.1.0"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/onevcat/Kingfisher.git",
       "state" : {
-        "revision" : "b6f62758f21a8c03cd64f4009c037cfa580a256e",
-        "version" : "7.9.1"
+        "revision" : "277f1ab2c6664b19b4a412e32b094b201e2d5757",
+        "version" : "7.10.0"
       }
     },
     {
@@ -104,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-syntax.git",
       "state" : {
-        "revision" : "013a48e2312e57b7b355db25bd3ea75282ebf274",
-        "version" : "0.50900.0-swift-DEVELOPMENT-SNAPSHOT-2023-02-06-a"
+        "revision" : "6ad4ea24b01559dde0773e3d091f1b9e36175036",
+        "version" : "509.0.2"
       }
     },
     {
@@ -113,8 +113,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/realm/SwiftLint.git",
       "state" : {
-        "revision" : "eb85125a5f293de3d3248af259980c98bc2b1faa",
-        "version" : "0.51.0"
+        "revision" : "f17a4f9dfb6a6afb0408426354e4180daaf49cee",
+        "version" : "0.54.0"
       }
     },
     {

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -113,7 +113,7 @@ platform :ios do
       derived_data_path: ".DerivedData", # Custom derived data path
       output_directory: "./build", # Directory where the output artifacts are generated
       scheme: "ArtemisExamCheck", # We want to build the "HallOfFame" scheme
-      xcargs: "-skipPackagePluginValidation"
+      xcargs: "-skipMacroValidation -skipPackagePluginValidation"
     )
   end
 


### PR DESCRIPTION
SwiftLint 0.54.0 and onwards uses Swift macros. We need to skip macro validation during CI.