### PR TITLE
`Exam mode`: Fix rendering all examinee rows on selection

### DIFF
--- a/ArtemisExamCheck.xcodeproj/project.pbxproj
+++ b/ArtemisExamCheck.xcodeproj/project.pbxproj
@@ -14,6 +14,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		A10986EB2B31CE3D007154FB /* .gitignore */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitignore; sourceTree = SOURCE_ROOT; };
+		A10986EC2B31CE3D007154FB /* fastlane */ = {isa = PBXFileReference; lastKnownFileType = text; path = fastlane; sourceTree = SOURCE_ROOT; };
+		A10986ED2B31CE3D007154FB /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = SOURCE_ROOT; };
+		A10986EE2B31CE3D007154FB /* Gemfile.lock */ = {isa = PBXFileReference; lastKnownFileType = file; path = Gemfile.lock; sourceTree = SOURCE_ROOT; };
+		A10986EF2B31CE3D007154FB /* LICENSE */ = {isa = PBXFileReference; lastKnownFileType = text; path = LICENSE; sourceTree = SOURCE_ROOT; };
+		A10986F02B31CE3D007154FB /* Gemfile */ = {isa = PBXFileReference; lastKnownFileType = text; path = Gemfile; sourceTree = SOURCE_ROOT; };
+		A10986F12B31CE3D007154FB /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = SOURCE_ROOT; };
 		A1B574072AFAA4FB00A54ACE /* ArtemisExamCheckKit */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = ArtemisExamCheckKit; sourceTree = "<group>"; };
 		D55C08312975A0E800DC6B80 /* ArtemisExamCheck.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ArtemisExamCheck.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D55C08342975A0E800DC6B80 /* ArtemisExamCheckApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtemisExamCheckApp.swift; sourceTree = "<group>"; };
@@ -55,6 +62,13 @@
 		D55C08332975A0E800DC6B80 /* ArtemisExamCheck */ = {
 			isa = PBXGroup;
 			children = (
+				A10986EC2B31CE3D007154FB /* fastlane */,
+				A10986EB2B31CE3D007154FB /* .gitignore */,
+				A10986ED2B31CE3D007154FB /* .swiftlint.yml */,
+				A10986F02B31CE3D007154FB /* Gemfile */,
+				A10986EE2B31CE3D007154FB /* Gemfile.lock */,
+				A10986EF2B31CE3D007154FB /* LICENSE */,
+				A10986F12B31CE3D007154FB /* README.md */,
 				D55C08342975A0E800DC6B80 /* ArtemisExamCheckApp.swift */,
 				D55C08382975A0EB00DC6B80 /* Assets.xcassets */,
 				D55C083A2975A0EB00DC6B80 /* Preview Content */,

--- a/ArtemisExamCheckKit/Sources/ArtemisExamCheckKit/Model/ExamUser.swift
+++ b/ArtemisExamCheckKit/Sources/ArtemisExamCheckKit/Model/ExamUser.swift
@@ -9,7 +9,7 @@ import Foundation
 import APIClient
 import UserStore
 
-struct ExamUser: Identifiable, Codable {
+struct ExamUser: Codable, Identifiable {
 
     let id: Int
 
@@ -69,7 +69,7 @@ struct ExamUser: Identifiable, Codable {
     }
 }
 
-struct User: Codable, Identifiable {
+struct User: Codable, Equatable, Identifiable {
     let id: Int
     let login: String
     let name: String
@@ -97,5 +97,3 @@ extension ExamUser: Equatable {
         lhs.signingImagePath == rhs.signingImagePath
     }
 }
-
-extension User: Equatable { }

--- a/ArtemisExamCheckKit/Sources/ArtemisExamCheckKit/ViewModels/ExamListViewModel.swift
+++ b/ArtemisExamCheckKit/Sources/ArtemisExamCheckKit/ViewModels/ExamListViewModel.swift
@@ -5,13 +5,13 @@
 //  Created by Sven Andabaka on 16.01.23.
 //
 
+import APIClient
+import Common
 import Foundation
 import UserStore
-import Common
-import APIClient
 
 @MainActor
-class ExamOverviewListViewModel: ObservableObject {
+class ExamListViewModel: ObservableObject {
 
     @Published var exams: DataState<[Exam]> = .loading
 

--- a/ArtemisExamCheckKit/Sources/ArtemisExamCheckKit/ViewModels/StudentListViewModel.swift
+++ b/ArtemisExamCheckKit/Sources/ArtemisExamCheckKit/ViewModels/StudentListViewModel.swift
@@ -5,8 +5,9 @@
 //  Created by Sven Andabaka on 16.01.23.
 //
 
-import Foundation
 import Common
+import Foundation
+import SwiftUI
 
 enum Sorting {
     case bottomToTop, topToBottom

--- a/ArtemisExamCheckKit/Sources/ArtemisExamCheckKit/Views/ContentView.swift
+++ b/ArtemisExamCheckKit/Sources/ArtemisExamCheckKit/Views/ContentView.swift
@@ -16,15 +16,9 @@ public struct ContentView: View {
 
     public var body: some View {
         if viewModel.isLoggedIn {
-            ExamOverviewList()
+            ExamListView()
         } else {
             LoginView()
         }
-    }
-}
-
-struct ContentView_Previews: PreviewProvider {
-    static var previews: some View {
-        ContentView()
     }
 }

--- a/ArtemisExamCheckKit/Sources/ArtemisExamCheckKit/Views/ExamListView.swift
+++ b/ArtemisExamCheckKit/Sources/ArtemisExamCheckKit/Views/ExamListView.swift
@@ -10,9 +10,9 @@ import Common
 import DesignLibrary
 import SwiftUI
 
-struct ExamOverviewList: View {
+struct ExamListView: View {
 
-    @StateObject private var viewModel = ExamOverviewListViewModel()
+    @StateObject private var viewModel = ExamListViewModel()
 
     var body: some View {
         NavigationStack {
@@ -47,7 +47,7 @@ struct ExamOverviewList: View {
     }
 }
 
-private extension ExamOverviewList {
+private extension ExamListView {
     func list(exams: [Exam]) -> some View {
         List(exams) { exam in
             NavigationLink(value: exam) {

--- a/ArtemisExamCheckKit/Sources/ArtemisExamCheckKit/Views/StudentListView.swift
+++ b/ArtemisExamCheckKit/Sources/ArtemisExamCheckKit/Views/StudentListView.swift
@@ -96,30 +96,33 @@ private extension StudentListView {
                             Text("There are no students. Maybe try removing some filters.")
                         }
                     } else {
-                        List(viewModel.selectedStudents, selection: $selectedStudent) { student in
-                            Button {
-                                if viewModel.hasUnsavedChanges {
-                                    unsavedUserAlert = true
-                                    nextSelectedStudent = student
-                                } else {
-                                    selectedStudent = student
+                        // ID allows users to select a single row.
+                        // List renders every row content on selection, if do not pass in an ID.
+                        List(viewModel.selectedStudents, id: \.self, selection: $selectedStudent) { student in
+                            HStack {
+                                VStack(alignment: .leading) {
+                                    Text(student.user.name)
+                                        .bold()
+                                    Text("Seat: \(student.actualSeat ?? student.plannedSeat ?? "not set")")
                                 }
-                            } label: {
-                                HStack {
-                                    VStack(alignment: .leading) {
-                                        Text(student.user.name)
-                                            .bold()
-                                        Text("Seat: \(student.actualSeat ?? student.plannedSeat ?? "not set")")
-                                    }
-                                    Spacer()
-                                    if student.isStudentDone {
-                                        Image(systemName: "checkmark.seal.fill")
-                                            .foregroundColor(.green)
-                                            .imageScale(.large)
-                                    }
+                                Spacer()
+                                if student.isStudentDone {
+                                    Image(systemName: "checkmark.seal.fill")
+                                        .foregroundColor(.green)
+                                        .imageScale(.large)
                                 }
                             }
-                            .listRowBackground(self.selectedStudent == student ? Color.gray.opacity(0.4) : Color.clear)
+                            // TODO: Button interferes with selection.
+                            // Button {
+                            //     if viewModel.hasUnsavedChanges {
+                            //         unsavedUserAlert = true
+                            //         nextSelectedStudent = student
+                            //     } else {
+                            //         selectedStudent = student
+                            //     }
+                            // } label: {
+                            // }
+                            // .listRowBackground(self.selectedStudent == student ? Color.gray.opacity(0.4) : Color.clear)
                         }
                     }
                 }

--- a/ArtemisExamCheckKit/Sources/ArtemisExamCheckKit/Views/StudentListView.swift
+++ b/ArtemisExamCheckKit/Sources/ArtemisExamCheckKit/Views/StudentListView.swift
@@ -22,7 +22,9 @@ struct StudentListView: View {
     }
 
     var images: [URL] {
-        guard let documentsDirectory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else { return [] }
+        guard let documentsDirectory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else {
+            return []
+        }
 
         return viewModel.exam.value?.examUsers?.compactMap { examUser in
             // format for name <examId>-<examUserId>-<examUserName>-<registrationNumber>.png
@@ -38,94 +40,117 @@ struct StudentListView: View {
     }
 
     var body: some View {
-        NavigationSplitView(sidebar: {
-            DataStateView(data: $viewModel.exam, retryHandler: { await viewModel.getExam() }) { _ in
-                VStack {
-                    Group {
-                        HStack {
-                            Picker("Room", selection: $viewModel.selectedLectureHall) {
-                                Text("All Rooms").tag("")
-                                ForEach(viewModel.lectureHalls, id: \.self) { lectureHall in
-                                    Text(lectureHall).tag(lectureHall)
-                                }
-                            }
-                            Picker("Sorting", selection: $viewModel.sortingDirection) {
-                                Text("Bottom to Top").tag(Sorting.bottomToTop)
-                                Text("Top to Bottom").tag(Sorting.topToBottom)
-                            }
-                        }
-                        Toggle("Hide Checked-In Students: ", isOn: $viewModel.hideDoneStudents)
-                            .padding(.horizontal, 8)
-                        Text("Progress: \(viewModel.checkedInStudentsInSelectedRoom) / \(viewModel.totalStudentsInSelectedRoom)")
-                    }.padding(.horizontal, 8)
-                    Group {
-                        if viewModel.selectedStudents.isEmpty {
-                            List {
-                                Text("There are no students. Maybe try removing some filters.")
-                            }
-                        } else {
-                            List(viewModel.selectedStudents, selection: $selectedStudent) { student in
-                                Button(action: {
-                                    if viewModel.hasUnsavedChanges {
-                                        unsavedUserAlert = true
-                                        nextSelectedStudent = student
-                                    } else {
-                                        selectedStudent = student
-                                    }
-                                }) {
-                                    HStack {
-                                        VStack(alignment: .leading) {
-                                            Text(student.user.name)
-                                                .bold()
-                                            Text("Seat: \(student.actualSeat ?? student.plannedSeat ?? "not set")")
-                                        }
-                                        Spacer()
-                                        if student.isStudentDone {
-                                            Image(systemName: "checkmark.seal.fill")
-                                                .foregroundColor(.green)
-                                                .imageScale(.large)
-                                        }
-                                    }
-                                }.listRowBackground(self.selectedStudent == student ? Color.gray.opacity(0.4) : Color.clear)
-                            }
-                        }
-                    }
-                        .searchable(text: $viewModel.searchText)
-                        .listStyle(SidebarListStyle())
-                        .refreshable {
-                            await viewModel.getExam(showLoadingIndicator: false)
-                        }
-                    if !images.isEmpty {
-                        ShareLink("Export Signatures", items: images)
-                    }
-                }
-            }
-        }, detail: {
-            if let studentBinding = Binding($selectedStudent),
-               let examId = viewModel.exam.value?.id,
-               let courseId = viewModel.exam.value?.course.id {
-                StudentDetailView(examId: examId,
-                                  courseId: courseId,
-                                  student: studentBinding,
-                                  hasUnsavedChanges: $viewModel.hasUnsavedChanges,
-                                  allRooms: $viewModel.lectureHalls,
-                                  successfullySavedCompletion: viewModel.updateStudent)
-                    .id(studentBinding.wrappedValue.id)
-            } else {
-                Text("Select a student")
-                    .font(.title)
-            }
-        })
+        NavigationSplitView {
+            sidebar
+        } detail: {
+            detail
+        }
         .navigationBarTitle(viewModel.exam.value?.title ?? "Loading...")
         .navigationBarTitleDisplayMode(.inline)
         .toolbarBackground(Color.blue, for: .navigationBar)
         .toolbarColorScheme(.dark, for: .navigationBar)
         .toolbarBackground(.visible, for: .navigationBar)
-        .alert("Unsaved Changes", isPresented: $unsavedUserAlert, actions: {
-            Button(role: .destructive, action: {
+        .alert("Unsaved Changes", isPresented: $unsavedUserAlert) {
+            Button.init(role: .destructive) {
                 selectedStudent = nextSelectedStudent
                 viewModel.hasUnsavedChanges = false
-            }, label: { Text("Delete Changes") })
-        }, message: { Text("You have unsaved changes. Changes are lost if you switch the student. Are you sure you want to continue?") })
+            } label: {
+                Text("Delete Changes")
+            }
+        } message: {
+            Text("You have unsaved changes. Changes are lost if you switch the student. Are you sure you want to continue?")
+        }
+    }
+}
+
+private extension StudentListView {
+    var sidebar: some View {
+        DataStateView(data: $viewModel.exam) { 
+            await viewModel.getExam()
+        } content: { _ in
+            VStack {
+                Group {
+                    HStack {
+                        Picker("Room", selection: $viewModel.selectedLectureHall) {
+                            Text("All Rooms").tag("")
+                            ForEach(viewModel.lectureHalls, id: \.self) { lectureHall in
+                                Text(lectureHall)
+                                    .tag(lectureHall)
+                            }
+                        }
+                        Picker("Sorting", selection: $viewModel.sortingDirection) {
+                            Text("Bottom to Top")
+                                .tag(Sorting.bottomToTop)
+                            Text("Top to Bottom")
+                                .tag(Sorting.topToBottom)
+                        }
+                    }
+                    Toggle("Hide Checked-In Students: ", isOn: $viewModel.hideDoneStudents)
+                        .padding(.horizontal, 8)
+                    Text("Progress: \(viewModel.checkedInStudentsInSelectedRoom) / \(viewModel.totalStudentsInSelectedRoom)")
+                }
+                .padding(.horizontal, 8)
+                Group {
+                    if viewModel.selectedStudents.isEmpty {
+                        List {
+                            Text("There are no students. Maybe try removing some filters.")
+                        }
+                    } else {
+                        List(viewModel.selectedStudents, selection: $selectedStudent) { student in
+                            Button {
+                                if viewModel.hasUnsavedChanges {
+                                    unsavedUserAlert = true
+                                    nextSelectedStudent = student
+                                } else {
+                                    selectedStudent = student
+                                }
+                            } label: {
+                                HStack {
+                                    VStack(alignment: .leading) {
+                                        Text(student.user.name)
+                                            .bold()
+                                        Text("Seat: \(student.actualSeat ?? student.plannedSeat ?? "not set")")
+                                    }
+                                    Spacer()
+                                    if student.isStudentDone {
+                                        Image(systemName: "checkmark.seal.fill")
+                                            .foregroundColor(.green)
+                                            .imageScale(.large)
+                                    }
+                                }
+                            }
+                            .listRowBackground(self.selectedStudent == student ? Color.gray.opacity(0.4) : Color.clear)
+                        }
+                    }
+                }
+                .searchable(text: $viewModel.searchText)
+                .listStyle(SidebarListStyle())
+                .refreshable {
+                    await viewModel.getExam(showLoadingIndicator: false)
+                }
+                if !images.isEmpty {
+                    ShareLink("Export Signatures", items: images)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder var detail: some View {
+        if let studentBinding = Binding($selectedStudent),
+           let examId = viewModel.exam.value?.id,
+           let courseId = viewModel.exam.value?.course.id {
+            StudentDetailView(
+                examId: examId,
+                courseId: courseId,
+                student: studentBinding,
+                hasUnsavedChanges: $viewModel.hasUnsavedChanges,
+                allRooms: $viewModel.lectureHalls,
+                successfullySavedCompletion: viewModel.updateStudent
+            )
+            .id(studentBinding.wrappedValue.id)
+        } else {
+            Text("Select a student")
+                .font(.title)
+        }
     }
 }

--- a/ArtemisExamCheckKit/Sources/ArtemisExamCheckKit/Views/StudentListView.swift
+++ b/ArtemisExamCheckKit/Sources/ArtemisExamCheckKit/Views/StudentListView.swift
@@ -97,7 +97,7 @@ private extension StudentListView {
                         }
                     } else {
                         // ID allows users to select a single row.
-                        // List renders every row content on selection, if do not pass in an ID.
+                        // List renders every row content on selection, if we do not pass it an ID.
                         List(viewModel.selectedStudents, id: \.self, selection: $selectedStudent) { student in
                             HStack {
                                 VStack(alignment: .leading) {
@@ -127,7 +127,6 @@ private extension StudentListView {
                     }
                 }
                 .searchable(text: $viewModel.searchText)
-                .listStyle(SidebarListStyle())
                 .refreshable {
                     await viewModel.getExam(showLoadingIndicator: false)
                 }


### PR DESCRIPTION
Closes #22
Closes #23

## As-is

https://github.com/ls1intum/ArtemisExamChecker/assets/23535000/7c8c1c6b-c10a-44b5-a15d-fa75be23c3dd

_`SwiftUI.List` renders every row content on selection, if we do not pass it an ID._
_The left window shows that SwiftUI reads 2000 button bodies, the number of students, when the user selects a new user._

## Vision

https://github.com/ls1intum/ArtemisExamChecker/assets/23535000/d2fd1c38-e8e5-41cb-b149-6a7415655b59

_`SwiftUI.List` does not render every row content on selection, if we pass it an ID._