### PR TITLE
`General`: Update TUM url

### DIFF
--- a/ArtemisExamCheck.xcodeproj/project.pbxproj
+++ b/ArtemisExamCheck.xcodeproj/project.pbxproj
@@ -332,7 +332,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_ASSET_PATHS = "\"ArtemisExamCheck/Preview Content\"";
-				DEVELOPMENT_TEAM = 2J3C6P6X3N;
+				DEVELOPMENT_TEAM = T7PP2KY2B6;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = ArtemisExamCheck/Supporting/Info.plist;
@@ -347,7 +347,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = de.tum.cit.artemis.examattendancechecker;
+				PRODUCT_BUNDLE_IDENTIFIER = de.tum.cit.ase.artemis.examsupervision;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
@@ -365,7 +365,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_ASSET_PATHS = "\"ArtemisExamCheck/Preview Content\"";
-				DEVELOPMENT_TEAM = 2J3C6P6X3N;
+				DEVELOPMENT_TEAM = T7PP2KY2B6;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = ArtemisExamCheck/Supporting/Info.plist;
@@ -380,7 +380,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = de.tum.cit.artemis.examattendancechecker;
+				PRODUCT_BUNDLE_IDENTIFIER = de.tum.cit.ase.artemis.examsupervision;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;

--- a/ArtemisExamCheck.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ArtemisExamCheck.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ls1intum/artemis-ios-core-modules",
       "state" : {
-        "branch" : "6e56881",
-        "revision" : "6e56881d5bd15980f16a82027dc922b99cc29525"
+        "revision" : "1d01cadb7ecc852a0ad6285f7fbc82f7d75e7af7",
+        "version" : "15.6.2"
       }
     },
     {

--- a/ArtemisExamCheck.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ArtemisExamCheck.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ls1intum/artemis-ios-core-modules",
       "state" : {
-        "revision" : "9c70eae3336c21f9de1e84ae7d25134d019b4dac",
-        "version" : "11.0.0"
+        "branch" : "6e56881",
+        "revision" : "6e56881d5bd15980f16a82027dc922b99cc29525"
       }
     },
     {
@@ -23,8 +23,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/krzyzanowskim/CryptoSwift.git",
       "state" : {
-        "revision" : "7892a123f7e8d0fe62f9f03728b17bbd4f94df5c",
-        "version" : "1.8.1"
+        "revision" : "729e01bc9b9dab466ac85f21fb9ee2bc1c61b258",
+        "version" : "1.8.4"
+      }
+    },
+    {
+      "identity" : "gzipswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/1024jp/GzipSwift.git",
+      "state" : {
+        "revision" : "56bf51fdd2fe4b2cf254b2cf34aede3d7caccc6c",
+        "version" : "6.1.0"
       }
     },
     {
@@ -32,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/onevcat/Kingfisher.git",
       "state" : {
-        "revision" : "5b92f029fab2cce44386d28588098b5be0824ef5",
-        "version" : "7.11.0"
+        "revision" : "2ef543ee21d63734e1c004ad6c870255e8716c50",
+        "version" : "7.12.0"
       }
     },
     {
@@ -41,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gonzalezreal/NetworkImage",
       "state" : {
-        "revision" : "7aff8d1b31148d32c5933d75557d42f6323ee3d1",
-        "version" : "6.0.0"
+        "revision" : "2849f5323265386e200484b0d0f896e73c3411b9",
+        "version" : "6.0.1"
       }
     },
     {
@@ -50,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mac-cain13/R.swift.git",
       "state" : {
-        "revision" : "384eab88d1a0b98ac96f4819e50a4308ecd5359f",
-        "version" : "7.5.0"
+        "revision" : "a9abc6b0afe0fc4a5a71e1d7d2872143dff2d2f1",
+        "version" : "7.8.0"
       }
     },
     {
@@ -59,8 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ashleymills/Reachability.swift",
       "state" : {
-        "revision" : "98e968e7b6c1318fb61df23e347bc319761e8acb",
-        "version" : "5.0.0"
+        "revision" : "21d1dc412cfecbe6e34f1f4c4eb88d3f912654a6",
+        "version" : "5.2.4"
       }
     },
     {
@@ -86,8 +95,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser.git",
       "state" : {
-        "revision" : "8f4d2753f0e4778c76d5f05ad16c74f707390531",
-        "version" : "1.2.3"
+        "revision" : "41982a3656a71c768319979febd796c6fd111d5c",
+        "version" : "1.5.0"
+      }
+    },
+    {
+      "identity" : "swift-cmark",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-cmark",
+      "state" : {
+        "revision" : "b022b08312decdc46585e0b3440d97f6f22ef703",
+        "version" : "0.6.0"
       }
     },
     {
@@ -95,8 +113,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gonzalezreal/swift-markdown-ui",
       "state" : {
-        "revision" : "ae799d015a5374708f7b4c85f3294c05f2a564e2",
-        "version" : "2.3.0"
+        "revision" : "5f613358148239d0292c0cef674a3c2314737f9e",
+        "version" : "2.4.1"
       }
     },
     {
@@ -104,8 +122,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-syntax.git",
       "state" : {
-        "revision" : "303e5c5c36d6a558407d364878df131c3546fad8",
-        "version" : "510.0.2"
+        "revision" : "2bc86522d115234d1f588efe2bcb4ce4be8f8b82",
+        "version" : "510.0.3"
       }
     },
     {
@@ -122,8 +140,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Romixery/SwiftStomp.git",
       "state" : {
-        "revision" : "99dcfa7f428485b92de2359c9df9c778fd2d5599",
-        "version" : "1.1.1"
+        "revision" : "f25926d2ab67ec0391de9a706cf71dfb08d36bbc",
+        "version" : "1.2.1"
       }
     },
     {
@@ -158,8 +176,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tomlokhorst/XcodeEdit",
       "state" : {
-        "revision" : "b6b67389a0f1a6fdd9c6457a8ab5b02eaab13c5c",
-        "version" : "2.9.2"
+        "revision" : "0e550cdee72844b35431afc3a1e176042be6d0f0",
+        "version" : "2.13.0"
       }
     },
     {
@@ -167,8 +185,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/jpsim/Yams.git",
       "state" : {
-        "revision" : "0d9ee7ea8c4ebd4a489ad7a73d5c6cad55d6fed3",
-        "version" : "5.0.6"
+        "revision" : "b4b8042411dc7bbb696300a34a4bf3ba1b7ad19b",
+        "version" : "5.3.1"
       }
     }
   ],

--- a/ArtemisExamCheck/Supporting/Info.plist
+++ b/ArtemisExamCheck/Supporting/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.0</string>
+	<string>1.0.1</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/ArtemisExamCheck/Supporting/Info.plist
+++ b/ArtemisExamCheck/Supporting/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.1</string>
+	<string>1.1.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/ArtemisExamCheck/Supporting/Info.plist
+++ b/ArtemisExamCheck/Supporting/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.0</string>
+	<string>1.1.1</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/ArtemisExamCheckKit/Package.swift
+++ b/ArtemisExamCheckKit/Package.swift
@@ -16,7 +16,8 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/daltoniam/Starscream", exact: "4.0.4"),
-        .package(url: "https://github.com/ls1intum/artemis-ios-core-modules", from: "11.0.0")
+        .package(url: "https://github.com/ls1intum/artemis-ios-core-modules", revision: "6e56881")
+//        .package(url: "https://github.com/ls1intum/artemis-ios-core-modules", from: "11.0.0")
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.

--- a/ArtemisExamCheckKit/Package.swift
+++ b/ArtemisExamCheckKit/Package.swift
@@ -16,8 +16,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/daltoniam/Starscream", exact: "4.0.4"),
-        .package(url: "https://github.com/ls1intum/artemis-ios-core-modules", revision: "6e56881")
-//        .package(url: "https://github.com/ls1intum/artemis-ios-core-modules", from: "11.0.0")
+        .package(url: "https://github.com/ls1intum/artemis-ios-core-modules", from: "15.6.2")
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.

--- a/ArtemisExamCheckKit/Sources/ArtemisExamCheckKit/Model/ExamUser.swift
+++ b/ArtemisExamCheckKit/Sources/ArtemisExamCheckKit/Model/ExamUser.swift
@@ -31,12 +31,12 @@ struct ExamUser: Codable, Identifiable {
 
     var signingImageURL: URL? {
         guard let signingImagePath else { return nil }
-        return URL(string: signingImagePath, relativeTo: UserSession.shared.institution?.baseURL)
+        return URL(string: signingImagePath, relativeTo: UserSessionFactory.shared.institution?.baseURL)
     }
 
     var imageURL: URL? {
         guard let studentImagePath else { return nil }
-        return URL(string: studentImagePath, relativeTo: UserSession.shared.institution?.baseURL)
+        return URL(string: studentImagePath, relativeTo: UserSessionFactory.shared.institution?.baseURL)
     }
 
     var isStudentDone: Bool {

--- a/ArtemisExamCheckKit/Sources/ArtemisExamCheckKit/ViewModels/ContentViewModel.swift
+++ b/ArtemisExamCheckKit/Sources/ArtemisExamCheckKit/ViewModels/ContentViewModel.swift
@@ -16,12 +16,12 @@ class ContentViewModel: ObservableObject {
     private var cancellables: Set<AnyCancellable> = Set()
 
     init() {
-        UserSession.shared.objectWillChange.sink {
+        UserSessionFactory.shared.objectWillChange.sink {
             DispatchQueue.main.async { [weak self] in
-                self?.isLoggedIn = UserSession.shared.isLoggedIn
+                self?.isLoggedIn = UserSessionFactory.shared.isLoggedIn
             }
         }.store(in: &cancellables)
 
-        isLoggedIn = UserSession.shared.isLoggedIn
+        isLoggedIn = UserSessionFactory.shared.isLoggedIn
     }
 }

--- a/ArtemisExamCheckKit/Sources/ArtemisExamCheckKit/Views/ExamListView.swift
+++ b/ArtemisExamCheckKit/Sources/ArtemisExamCheckKit/Views/ExamListView.swift
@@ -42,7 +42,7 @@ struct ExamListView: View {
             .toolbarBackground(Color.blue, for: .navigationBar)
             .toolbarColorScheme(.dark, for: .navigationBar)
             .toolbarBackground(.visible, for: .navigationBar)
-            .accountMenu(error: $viewModel.error, notificationsVisible: false)
+            .accountMenu(error: $viewModel.error)
         }
     }
 }

--- a/ArtemisExamCheckKit/Sources/ArtemisExamCheckKit/Views/StudentListView.swift
+++ b/ArtemisExamCheckKit/Sources/ArtemisExamCheckKit/Views/StudentListView.swift
@@ -124,6 +124,7 @@ private extension StudentListView {
                             // }
                             // .listRowBackground(self.selectedStudent == student ? Color.gray.opacity(0.4) : Color.clear)
                         }
+                        .listStyle(.plain)
                     }
                 }
                 .searchable(text: $viewModel.searchText)

--- a/ArtemisExamCheckKit/Sources/ArtemisExamCheckKit/Views/StudentListView.swift
+++ b/ArtemisExamCheckKit/Sources/ArtemisExamCheckKit/Views/StudentListView.swift
@@ -124,7 +124,6 @@ private extension StudentListView {
                             // }
                             // .listRowBackground(self.selectedStudent == student ? Color.gray.opacity(0.4) : Color.clear)
                         }
-                        .listStyle(.plain)
                     }
                 }
                 .searchable(text: $viewModel.searchText)


### PR DESCRIPTION
The Artemis instance of TUM is reachable via `artemis.tum.de` instead of `artemis.ase.in.tum.de` which we used previously.