### PR TITLE
`General`: Remove staging as default instance

### DIFF
--- a/ArtemisExamCheck/Supporting/Info.plist
+++ b/ArtemisExamCheck/Supporting/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.0</string>
+	<string>2.0.1</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/ArtemisExamCheckKit/Sources/ArtemisExamCheckKit/ViewModels/ContentViewModel.swift
+++ b/ArtemisExamCheckKit/Sources/ArtemisExamCheckKit/ViewModels/ContentViewModel.swift
@@ -23,11 +23,5 @@ class ContentViewModel: ObservableObject {
         }.store(in: &cancellables)
 
         isLoggedIn = UserSessionFactory.shared.isLoggedIn
-
-        // Set default instance to staging for App Review before April 14 evening
-        let releaseDate8 = Date(timeIntervalSinceReferenceDate: 766_350_000)
-        if !isLoggedIn && Date.now < releaseDate8 {
-            UserSessionFactory.shared.saveInstitution(identifier: .custom(URL(string: "https://artemis-staging-localci.artemis.cit.tum.de")))
-        }
     }
 }


### PR DESCRIPTION
For App Review in Version 2.0, we temporarily needed to set staging as the default instance for login. This is no longer required, thus we remove it.