### PR TITLE
`General`: Release 3.1.1

### DIFF
--- a/ArtemisExamCheck/Supporting/Info.plist
+++ b/ArtemisExamCheck/Supporting/Info.plist
@@ -23,7 +23,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.1.0</string>
+	<string>3.1.1</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/ArtemisExamCheckKit/Sources/ArtemisExamCheckKit/Views/SearchStudentView.swift
+++ b/ArtemisExamCheckKit/Sources/ArtemisExamCheckKit/Views/SearchStudentView.swift
@@ -18,6 +18,7 @@ struct SearchStudentView: View {
                     Button {
                         viewModel.moveStudent(student, to: ExamUserLocationDTO(room: search.room, seat: search.seat))
                         viewModel.selectedSearch = nil
+                        viewModel.searchText = ""
                         viewModel.hasUnsavedChanges = true
                         DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
                             viewModel.selectedStudent = student
@@ -34,6 +35,7 @@ struct SearchStudentView: View {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Cancel") {
                         viewModel.selectedSearch = nil
+                        viewModel.searchText = ""
                     }
                 }
             }

--- a/ArtemisExamCheckKit/Sources/ArtemisExamCheckKit/Views/StudentDetailView/EditSeatView.swift
+++ b/ArtemisExamCheckKit/Sources/ArtemisExamCheckKit/Views/StudentDetailView/EditSeatView.swift
@@ -8,16 +8,23 @@
 import SwiftUI
 
 struct EditSeatView: View {
-    @Environment(\.dismiss) private var dismiss
+    @Environment(\.dismiss)
+    private var dismiss
     @Bindable var viewModel: StudentDetailViewModel
     let examViewModel: ExamViewModel
+
+    var allRoomNumbers: [String] {
+        let allUsed = viewModel.allRooms
+        let allPossible = examViewModel.exam.value?.examRoomsUsedInExam?.map(\.roomNumber) ?? []
+        return Array(Set(allPossible + allUsed))
+    }
 
     var body: some View {
         NavigationStack {
             Form {
                 Section {
                     Picker("Room", selection: $viewModel.actualRoom) {
-                        ForEach(viewModel.allRooms, id: \.self) { room in
+                        ForEach(allRoomNumbers, id: \.self) { room in
                             Button {} label: {
                                 let displayName = examViewModel.getRoomDisplayName(for: room)
                                 Text(displayName)

--- a/ArtemisExamCheckKit/Sources/ArtemisExamCheckKit/Views/StudentDetailView/EditSeatView.swift
+++ b/ArtemisExamCheckKit/Sources/ArtemisExamCheckKit/Views/StudentDetailView/EditSeatView.swift
@@ -32,6 +32,11 @@ struct EditSeatView: View {
 
                     if hasSelectedCustomRoom {
                         TextField("Room", text: $viewModel.actualRoom)
+                            .onChange(of: viewModel.actualRoom) { oldValue, newValue in
+                                if oldValue != newValue && newValue.count > 100 {
+                                    viewModel.actualRoom = String(newValue.prefix(100))
+                                }
+                            }
                     }
                 }
 
@@ -45,6 +50,11 @@ struct EditSeatView: View {
                         }
                         if hasSelectedCustomSeat {
                             TextField("Seat", text: $viewModel.actualSeat)
+                                .onChange(of: viewModel.actualSeat) { oldValue, newValue in
+                                    if oldValue != newValue && newValue.count > 100 {
+                                        viewModel.actualSeat = String(newValue.prefix(100))
+                                    }
+                                }
                         }
                     } else {
                         HStack {


### PR DESCRIPTION
This update fixes:
- Empty rooms not being selectable when moving students to different seats
- List View being almost empty after re-seating students in the room view using search
- Seat/Room edits failing to save if more than 100 characters were entered